### PR TITLE
Coder updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { readFile, writeFile } from 'fs/promises';
 const srcImage = await readFile('my-image.neo');
 
 // Decode NEO file into ImageData and return its indexed palette
-const { imageData } = await decode(srcImage.buffer);
+const { imageData, palette } = await decode(srcImage.buffer);
 
 // Encode the ImageData to PNG format
 const outBuffer = await encode(imageData);
@@ -30,7 +30,10 @@ await writeFile(destFilepath, Buffer.from(outBuffer));
 * `imagedata` - Implementation of the [`ImageData` interface](https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-dev)
 * `imagedata-coder-bitplane` - Convert from/to bitplane format
 * `imagedata-coder-blit` - Copy pixels between `ImageData`.
+* `imagedata-coder-crackart` - Decode Atari ST Crack Art images
 * `imagedata-coder-degas` - Encode / decode Atari ST [Degas](https://en.wikipedia.org/wiki/DEGAS_(software)) images
 * `imagedata-coder-iff` - Decode Amiga [IFF](https://en.wikipedia.org/wiki/Interchange_File_Format) images.
 * `imagedata-coder-neochrome` - Encode / decode Atari ST [NEOchrome](https://en.wikipedia.org/wiki/NEOchrome) images
 * `imagedata-coder-png` - Ecode / decode [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics) images. Uses [pngjs](https://github.com/lukeapage/pngjs).
+* `imagedata-coder-spectrum512` - Decode Atari ST [Spectrum 512](http://www.atarimania.com/utility-atari-st-spectrum-512_22312.html) images
+

--- a/imagedata-coder-bitplane/decode.js
+++ b/imagedata-coder-bitplane/decode.js
@@ -18,6 +18,8 @@ import { IndexedPalette } from './IndexedPalette.js';
  */
 export const decode = (buffer, palette, imageWidth, options = {}) => new Promise(resolve => {
 
+  let planes;
+
   // Ensure the image width is a multiple of 16 pixels  
   if (imageWidth % 16 !== 0) {
     throw new Error('Image width must be multiple of 16');
@@ -35,8 +37,13 @@ export const decode = (buffer, palette, imageWidth, options = {}) => new Promise
     colors = palette;
   }
 
-  // Ensure the palette contains enough entries to decode the number of planes
-  let planes = Math.log(palette.length) / Math.log(2);
+  if ('planes' in options) {
+    planes = options.planes;
+  } else {
+    // Ensure the palette contains enough entries to decode the number of planes
+    planes = Math.log(palette.length) / Math.log(2);
+  }
+
   if (!Number.isInteger(planes)) {
     throw new Error('Palette length must be a power of 2');
   }
@@ -64,40 +71,75 @@ export const decode = (buffer, palette, imageWidth, options = {}) => new Promise
 
 const decodeContiguous = (bufferView, imageDataView, colors, planes, bitPlaneLength) => {
   for (let wordIndex = 0; wordIndex < bitPlaneLength; wordIndex++) {
-    for (let bit = 0; bit < 16; bit++) {
-      let colorIndex = 0;
-      for (let plane = 0; plane < planes; plane++) {
-        const offset = (plane * bitPlaneLength + wordIndex) * 2;
-        colorIndex |= (bufferView.getUint16(offset) >> (15 - bit) & 1) << plane;
-      }
-      imageDataView.setUint32((wordIndex * 16 + bit) * 4, colors[colorIndex]);
-    }
+    const indexes = decodeWordsToPaletteIndexes(bufferView, wordIndex * 2, planes, bitPlaneLength);
+    indexes.forEach((index, i) => {
+      imageDataView.setUint32(((wordIndex * 16) + i) * 4, colors[index]);
+    })
   }
 };
 
 const decodeInterleavedWord = (bufferView, imageDataView, colors, planes, bitPlaneLength) => {
   for (let wordIndex = 0; wordIndex < bitPlaneLength; wordIndex++) {
-    for (let bit = 0; bit < 16; bit++) {
-      let colorIndex = 0;
-      for (let plane = 0; plane < planes; plane++) {
-        const offset = (wordIndex * planes + plane) * 2;
-        colorIndex |= (bufferView.getUint16(offset) >> (15 - bit) & 1) << plane;
-      }
-      imageDataView.setUint32((wordIndex * 16 + bit) * 4, colors[colorIndex]);
-    }
+    const indexes = decodeWordsToPaletteIndexes(bufferView, wordIndex * 8, planes, 1);
+    indexes.forEach((index, i) => {
+      imageDataView.setUint32(((wordIndex * 16) + i) * 4, colors[index]);
+    })
   }
 };
 
 const decodeInterleavedLine = (bufferView, imageDataView, colors, planes, bitPlaneLength, wordsPerLine) => {
-  for (let wordIndex = 0; wordIndex < bitPlaneLength; wordIndex++) {
-    for (let bit = 0; bit < 16; bit++) {
-      let colorIndex = 0;
-      for (let plane = 0; plane < planes; plane++) {
-        const line = Math.floor(wordIndex / wordsPerLine);
-        const offset = (line * planes + plane) * 2 * wordsPerLine + ((wordIndex % wordsPerLine)) * 2;
-        colorIndex |= (bufferView.getUint16(offset) >> (15 - bit) & 1) << plane;
-      }
-      imageDataView.setUint32((wordIndex * 16 + bit) * 4, colors[colorIndex]);
+  let p = 0;
+  for (let wordIndex = 0; wordIndex < bitPlaneLength; wordIndex += wordsPerLine) {
+    for (let w = 0; w < wordsPerLine; w++) {
+      const indexes = decodeWordsToPaletteIndexes(bufferView, p + (w * 2), planes, wordsPerLine);
+      indexes.forEach((index, i) => {
+        imageDataView.setUint32(((wordIndex * 16) + i + w * 16) * 4, colors[index]);
+      })
     }
+    p += wordsPerLine * planes * 2;
   }
+};
+
+/**
+ * Converts 16 bits (one word) of bitplane data to an array of color indexes
+ * 
+ * @param {DataView} bufferView - A view of the buffer to extract data from
+ * @param {Number} offset - Offset into the buffer
+ * @param {Number} planes - Number of bitplanes in the image data
+ * @param {Number} planeOffset - Number of words between bitplanes
+ * @returns {Array<Number>} - Array of color indexes
+ */
+export const decodeWordsToPaletteIndexes = (bufferView, offset, planes, planeOffset = 1) => {
+  const colors = [];
+  for (let bit = 0; bit < 16; bit++) {
+    let colorIndex = 0;
+    for (let plane = 0; plane < planes; plane++) {
+      const wordOffset = offset + (planeOffset * plane * 2);
+      colorIndex |= (bufferView.getUint16(wordOffset) >> (15 - bit) & 1) << plane;
+    }
+    colors.push(colorIndex);
+  }
+  return colors;
+};
+
+/**
+ * Converts 8 bits (one byte) of bitplane data to an array of color indexes
+ * 
+ * @param {DataView} bufferView - A view of the buffer to extract data from
+ * @param {Number} offset - Offset into the buffer
+ * @param {Number} planes - Number of bitplanes in the image data
+ * @param {Number} planeOffset - Number of bytes between bitplanes
+ * @returns {Array<Number>} - Array of color indexes
+ */
+export const decodeBytesToPaletteIndexes = (bufferView, offset, planes, planeOffset = 1) => {
+  const colors = [];
+  for (let bit = 0; bit < 8; bit++) {
+    let colorIndex = 0;
+    for (let plane = 0; plane < planes; plane++) {
+      const byteOffset = offset + (planeOffset * plane);
+      colorIndex |= (bufferView.getUint8(byteOffset) >> (7 - bit) & 1) << plane;
+    }
+    colors.push(colorIndex);
+  }
+  return colors;
 };

--- a/imagedata-coder-bitplane/index.js
+++ b/imagedata-coder-bitplane/index.js
@@ -1,5 +1,5 @@
 export { encode } from './encode.js';
-export { decode } from './decode.js';
+export { decode, decodeWordsToPaletteIndexes, decodeBytesToPaletteIndexes } from './decode.js';
 export { IndexedPalette } from './IndexedPalette.js';
 export { 
   ENCODING_FORMAT_CONTIGUOUS,

--- a/imagedata-coder-crackart/.gitignore
+++ b/imagedata-coder-crackart/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/imagedata-coder-crackart/compression.js
+++ b/imagedata-coder-crackart/compression.js
@@ -1,0 +1,81 @@
+export const decompress = (buffer) => {
+
+  const writeByte = (byte) => {
+    location[nextPos] = byte;
+    nextPos += offset;
+    remaining--;
+    if (nextPos >= size) {
+      nextStart++;
+      nextPos = nextStart;
+    }
+  };
+
+  const readWord = () => {
+    return inView.getUint16(inPos += 2);
+  };
+
+  const readByte = () => {
+    return inView.getUint8(inPos++);
+  };
+
+  const outLength = 32000;
+  const inView = new DataView(buffer);
+  const escape = inView.getUint8(0);
+  const initial = inView.getUint8(1);
+  const offset = inView.getInt16(2);
+  const location = new Uint8Array(outLength).fill(initial);
+
+  let inPos = 4;
+  let size = outLength;
+  let remaining = outLength;
+  let nextStart = 0;
+  let nextPos = 0;
+
+  while (remaining) {
+    let length;
+    let byte;
+    let code = readByte();
+
+    if (code !== escape) {
+      writeByte(code);
+    } else {
+      code = readByte();
+      if (code === escape) {
+        writeByte(code);
+      } else if (code === 0) {
+        length = readByte() + 1;
+        byte = readByte();
+        while (length--) {
+          writeByte(byte);
+        }
+      } else if (code === 1) {
+        length = readWord() + 1;
+        byte = readByte();
+        while (length--) {
+          writeByte(byte);
+        }
+      } else if (code === 2) {
+        length = readByte();
+        if (length) {
+          length <<= 8;
+          length += readByte() + 1;
+          while (length--) {
+            writeByte(initial);
+          }
+        } else {
+          while (remaining) {
+            writeByte(initial);
+          }
+        }
+      } else {
+        length = code + 1;
+        byte = readByte();
+        while (length--) {
+          writeByte(byte);
+        }
+      }
+    }
+  }
+
+  return location.buffer;
+};

--- a/imagedata-coder-crackart/consts.js
+++ b/imagedata-coder-crackart/consts.js
@@ -1,0 +1,3 @@
+export const FILE_HEADER = 0x4341;
+
+export const ERROR_MESSAGE_INVALID_FILE_FORMAT = 'Invalid file format';

--- a/imagedata-coder-crackart/decode.js
+++ b/imagedata-coder-crackart/decode.js
@@ -1,0 +1,76 @@
+import { IndexedPalette, decode as decodeBitplanes } from 'imagedata-coder-bitplane';
+import { decompress } from './compression.js';
+import { ERROR_MESSAGE_INVALID_FILE_FORMAT, FILE_HEADER } from './consts.js';
+
+/**
+ * @typedef {import('./types.js').DecodedImage} DecodedImage
+ */
+
+
+/**
+ * Decodes a Crack Art image and returns a ImageData object containing the
+ * converted data. Colors are converted from 12bit RGB to 32bit RGBA format.
+ * Supports CA1, CA2 and CA3 formats.
+ *
+ * @param {ArrayBuffer} buffer - An array buffer containing the NEOChrome image
+ * @returns {Promise<DecodedImage>} Decoded image data
+ * @throws {Error} If the image data is invalid
+ */
+export const decode = async buffer => {
+  const dataView = new DataView(buffer);
+
+  if (dataView.getUint16(0) !== FILE_HEADER) {
+    throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+  }
+
+  const compressed = dataView.getUint8(2);
+  const res = dataView.getUint8(3);
+
+  if ((compressed !== 1 && compressed !== 0) || (res < 0 || res > 2)) {
+    throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+  }
+
+  let palette;
+  let pos = 4;
+
+  if (res === 2) {
+    palette = new IndexedPalette(2, { bitsPerChannel: 1 });
+    palette.setColor(0, 0, 0, 0);
+    palette.setColor(1, 1, 1, 1);
+  } else {
+    if (res === 0) {
+      palette = new IndexedPalette(16, { bitsPerChannel: 3 });
+    } else {
+      palette = new IndexedPalette(4, { bitsPerChannel: 3 });
+    }
+
+    for (let index = 0; index < palette.length; index++) {
+      const color = dataView.getUint16(pos);
+
+      // Decode into R, G and B components
+      const r = color >> 8 & 0xf;
+      const g = color >> 4 & 0xf;
+      const b = color >> 0 & 0xf;
+
+      // Set the indexed color in the palette
+      palette.setColor(index, r, g, b);
+
+      pos += 2;
+    }
+  }
+
+  const width = res === 0 ? 320 : 640;
+  let bitplaneData = buffer.slice(pos);
+
+  if (compressed) {
+    bitplaneData = decompress(bitplaneData);
+  }
+
+  const imageData = await decodeBitplanes(bitplaneData, palette, width, { format: 'word' });
+
+  return {
+    palette,
+    imageData
+  };
+
+};

--- a/imagedata-coder-crackart/main.js
+++ b/imagedata-coder-crackart/main.js
@@ -1,0 +1,1 @@
+export { decode } from './decode.js';

--- a/imagedata-coder-crackart/package-lock.json
+++ b/imagedata-coder-crackart/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "imagedata-coder-crackart",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "imagedata-coder-crackart",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
+      }
+    },
+    "../imagedata-coder-bitplane": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "imagedata": "../imagedata"
+      }
+    },
+    "node_modules/imagedata-coder-bitplane": {
+      "resolved": "../imagedata-coder-bitplane",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "imagedata-coder-bitplane": {
+      "version": "file:../imagedata-coder-bitplane",
+      "requires": {}
+    }
+  }
+}

--- a/imagedata-coder-crackart/package.json
+++ b/imagedata-coder-crackart/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "imagedata-coder-crackart",
+  "version": "1.0.0",
+  "description": "A coder for working with Crack Art files in ImageData objects.",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
+  },
+  "author": {
+    "name": "Keith Clark",
+    "url": "https://keithclark.co.uk"
+  },
+  "license": "MIT",
+  "type": "module"
+}

--- a/imagedata-coder-crackart/types.js
+++ b/imagedata-coder-crackart/types.js
@@ -1,0 +1,7 @@
+/**
+ * @typedef {Object} DecodedImage
+ * @property {IndexedPalette} palette - The indexed palette containing the image colors
+ * @property {ImageData} imageData - The ImageData object containing the image
+ */
+
+export default null;

--- a/imagedata-coder-degas/main.js
+++ b/imagedata-coder-degas/main.js
@@ -1,6 +1,9 @@
-import { decode as decodeBitplanes, encode as encodeBitplanes } from 'imagedata-bitplane-coder';
-import { depack } from 'imagedata-bitplane-coder/compression/packbits.js';
-import { IndexedPalette } from 'imagedata-bitplane-coder';
+import { decode as decodeBitplanes, encode as encodeBitplanes } from 'imagedata-coder-bitplane';
+import { depack } from 'imagedata-coder-bitplane/compression/packbits.js';
+import { IndexedPalette } from 'imagedata-coder-bitplane';
+
+const STE_4096_COLOR_BITMASK = 0b100010001000;
+
 /**
  * Decodes a Degas image and generates a ImageData object containing the
  * converted data, along with the original image palette.
@@ -19,22 +22,49 @@ export const decode = async buffer => {
   const dataView = new DataView(buffer);
   const compressed = dataView.getUint8(0);
   const res = dataView.getUint8(1);
+
   let bitplaneData;
   let imageData;
+  let bitsPerChannel = 3;
+
   if ((compressed !== 0x80 && compressed !== 0) || (res < 0 || res > 2)) {
     throw new Error('Invalid file format');
   }
 
   const width = res === 0 ? 320 : 640;
   const planes = 4 >> res;
+  const colors = 1 << planes;
+
+  // Determine if the palette is using the STe 4096 color format or not.
+  for (let index = 0; index < colors; index++) {
+    const color = dataView.getUint16(2 + index * 2);
+    if (color & STE_4096_COLOR_BITMASK) {
+      bitsPerChannel = 4;
+      break;
+    }
+  }
 
   // Extract the palette
-  const palette = new IndexedPalette(1 << planes, { bitsPerChannel: 3 });
-  for (let index = 0; index < palette.length; index++) {
+  const palette = new IndexedPalette(colors, { bitsPerChannel });
+  for (let index = 0; index < colors; index++) {
     const color = dataView.getUint16(2 + index * 2);
-    const r = color >> 8 & 0xf;
-    const g = color >> 4 & 0xf;
-    const b = color >> 0 & 0xf;
+
+    // Decode into R, G and B components
+    let r = color >> 8 & 0xf;
+    let g = color >> 4 & 0xf;
+    let b = color >> 0 & 0xf;
+
+    // For backwards compatability reasons, the Atari STe stores the least 
+    // significant color bit for each channel in bit 4 (The standard ST only 
+    // reads bits 1-3). If the palette is using all four bits the we need
+    // reorder them before converting to 32 bit color.
+    if (bitsPerChannel === 4) {
+      r = ((r & 8) >>> 3) | (r << 1) & 0xf;
+      g = ((g & 8) >>> 3) | (g << 1) & 0xf;
+      b = ((b & 8) >>> 3) | (b << 1) & 0xf;     
+    }
+
+    // Set the indexed color in the palette
     palette.setColor(index, r, g, b);
   }
 
@@ -59,13 +89,14 @@ export const decode = async buffer => {
  * 
  * @param {ImageData} imageData - The image data to encode
  * @param {IndexedPalette} palette - The color palette to use
+ * @param {Boolean} steColor - If true, encode the color channels as 4 bit. Otherwise, 3 bits is used
+ * @param {Boolean} compress - If true, the image data is compressed
  * @returns {Promise<ArrayBuffer>} - The encoded Degas image bytes
  */
-export const encode = async (imageData, palette, compress = false) => {
+export const encode = async (imageData, palette, steColor = false, compress = false) => {
   const buffer = new ArrayBuffer(32034);
   const uint8View = new Uint8Array(buffer);
   const dataView = new DataView(buffer);
-
   let res;
 
   if (imageData.width === 320 && imageData.height === 200) {
@@ -86,11 +117,32 @@ export const encode = async (imageData, palette, compress = false) => {
 
   // Degas colours are always stored rrrr,gggg,bbbb - even if the colour is only
   // 3 bits per channel.
-  const colors = palette.resample(3).toValueArray(4, false);
+  let colors;
+  if (!steColor) {
+    // Standard ST palette is 3 bits per channel stored over 4 bits: 0rrr0ggg0bbb
+    colors = palette.resample(3).toValueArray(4, false);
+    for (let index = 0; index < colors.length; index++) {
+      dataView.setUint16(2 + index * 2, colors[index]);
+    }
+  } else {
+    // Enhanced ST palette is 4 bits: rrrrggggbbbb but LSB is stored in bit 4 so
+    // colours still render on a standard ST.
+    colors = palette.resample(4).toValueArray(4, false);
+    for (let index = 0; index < colors.length; index++) {
+      let color = colors[index];
 
-  // Encode the palette
-  for (let index = 0; index < colors.length; index++) {
-    dataView.setUint16(2 + index * 2, colors[index]);
+      // Decode into R, G and B components
+      const r = color >> 8 & 0xf;
+      const g = color >> 4 & 0xf;
+      const b = color >> 0 & 0xf;
+
+      // Rotate the bits so LSB becomes MSB
+      const steR = (r >> 1) + ((r & 1) << 3);
+      const steG = (g >> 1) + ((g & 1) << 3);
+      const steB = (b >> 1) + ((b & 1) << 3);
+      const steColor = (steR << 8) + (steG << 4) + steB;
+      dataView.setUint16(2 + index * 2, steColor);
+    }
   }
 
   // Encode the bitplanes

--- a/imagedata-coder-degas/package-lock.json
+++ b/imagedata-coder-degas/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "imagedata-bitplane-coder": "file:../imagedata-coder-bitplane"
+        "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
       }
     },
     "../imagedata-coder-bitplane": {
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "peerDependencies": {
         "imagedata": "../imagedata"
       }
@@ -24,13 +24,13 @@
       "extraneous": true,
       "license": "MIT"
     },
-    "node_modules/imagedata-bitplane-coder": {
+    "node_modules/imagedata-coder-bitplane": {
       "resolved": "../imagedata-coder-bitplane",
       "link": true
     }
   },
   "dependencies": {
-    "imagedata-bitplane-coder": {
+    "imagedata-coder-bitplane": {
       "version": "file:../imagedata-coder-bitplane",
       "requires": {}
     }

--- a/imagedata-coder-degas/package.json
+++ b/imagedata-coder-degas/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "imagedata-bitplane-coder": "file:../imagedata-coder-bitplane"
+    "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
   },
   "author": {
     "name": "Keith Clark",

--- a/imagedata-coder-spectrum512/.gitignore
+++ b/imagedata-coder-spectrum512/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/imagedata-coder-spectrum512/BitReader.js
+++ b/imagedata-coder-spectrum512/BitReader.js
@@ -1,0 +1,42 @@
+/**
+ * A low-level interface for reading data at a bit level
+ */
+export default class BitDataView {
+
+  /**
+   * @type {DataView}
+   */
+  #view;
+
+  /**
+   * @param {ArrayBuffer} buffer The `ArrayBuffer` to read bits from
+   */
+  constructor(buffer) {
+    this.#view = new DataView(buffer);
+  }
+
+  /**
+   * Reads a stream of bits from the buffer.
+   * 
+   * @param {Number} offset - Bit to start reading from
+   * @param {Number} length - Number of bits to read (1 - 32)
+   * @returns {Number} The unsigned numerical value of the bits
+   * @throws {RangeError} if the number of bits is invalid or out of range. 
+   */
+  getBits(offset, length) {
+    const byteOffset = (offset >> 3);
+    const bitOffset = offset % 8;
+    const mask = 0xffffffff >> (32 - length);
+
+    if (bitOffset + length <= 8) {
+      return ((this.#view.getUint8(byteOffset) >> (8 - bitOffset - length)) & mask) >>> 0;
+    } else if (bitOffset + length <= 16) {
+      return ((this.#view.getUint16(byteOffset) >> (16 - bitOffset - length)) & mask) >>> 0;
+    } else if (bitOffset + length <= 32) {
+      return ((this.#view.getUint32(byteOffset) >> (32 - bitOffset - length)) & mask) >>> 0;
+    } else {
+      throw new RangeError();
+    }
+  }
+
+};

--- a/imagedata-coder-spectrum512/common.js
+++ b/imagedata-coder-spectrum512/common.js
@@ -1,0 +1,59 @@
+/**
+ * Generates a palette lookup table
+ * 
+ * @param {DataView} paletteView - A DataView of the buffer containing the palette
+ * @returns {Array<Number>} Array of colours
+ */
+export const createPalette = (paletteView) => {
+  const palette = new Array(48 * 199);
+  let q = 0;
+  let isSte = false;
+  let scale = 255 / 15;
+  for (let line = 0; line < 199; line++) {
+    for (let c = 0; c < 48; c++) {
+      const color = paletteView.getUint16(line * 2 * 48 + c * 2);
+      let r = color >> 8 & 0xf;
+      let g = color >> 4 & 0xf;
+      let b = color >> 0 & 0xf;
+
+      if (!isSte && (r > 7 | g > 7 | b > 7)) {
+        isSte = true;
+      }
+
+      r = ((r & 8) >>> 3) | (r << 1) & 0xf;
+      g = ((g & 8) >>> 3) | (g << 1) & 0xf;
+      b = ((b & 8) >>> 3) | (b << 1) & 0xf;
+
+      palette[q++] = ((scale * r) << 24) + ((scale * g) << 16) + ((scale * b) << 8) + 255 >>> 0;
+    }
+  }
+
+  return {
+    bitsPerChannel: isSte ? 4 : 3,
+    palette
+  };
+};
+
+
+/**
+ * 
+ * @param {Number} x - X pixel
+ * @param {Number} y - Y pixel
+ * @param {Number} c - Colour index
+ * @returns {Number} the index into the palette
+ */
+export const getPaletteColorOffset = (x, y, c) => {
+  let x1 = 10 * c;
+
+  if (c % 2) {
+    x1 -= 5;
+  } else {
+    x1 += 1;
+  }
+  if (x >= x1 && x < x1 + 160) {
+    c += 16;
+  } else if (x >= x1 + 160) {
+    c += 32;
+  }
+  return c + (y * 48);
+};

--- a/imagedata-coder-spectrum512/compressed.js
+++ b/imagedata-coder-spectrum512/compressed.js
@@ -1,0 +1,129 @@
+import ImageData from 'imagedata';
+import { IndexedPalette, decodeWordsToPaletteIndexes } from 'imagedata-coder-bitplane';
+import { createPalette, getPaletteColorOffset } from './common.js';
+import {
+  COLORS_PER_SCANLINE,
+  ERROR_MESSAGE_INVALID_FILE_FORMAT,
+  IMAGE_HEIGHT,
+  IMAGE_WIDTH,
+  SPECTRUM_FILE_HEADER
+} from './consts.js';
+
+
+/**
+ * Decompresses the palette.
+ * 
+ * Each 16 colour palette consists of a header word followed by the colour data.
+ * The header word is a 16 bit mask where a `1` indicates the colour exists in
+ * the colour data and `0` indicates the colour isn't and should be treated as
+ * black. 
+ * 
+ * @param {ArrayBuffer} buffer - The `ArrayBuffer` containing the compressed data
+ * @returns {ArrayBuffer} - A `ArrayBuffer` containing the uncompressed data
+ */
+export const decompressPalette = (buffer) => {
+  const palette = new ArrayBuffer(COLORS_PER_SCANLINE * IMAGE_HEIGHT * 2);
+  const paletteView = new DataView(palette);
+  const srcView = new DataView(buffer);
+  let outPos = 0;
+  let srcPos = 0;
+  while (srcPos < buffer.byteLength) {
+    let paletteMask = srcView.getUint16(srcPos);
+    srcPos += 2;
+    for (let c = 0; c < 16; c++) {
+      if (paletteMask & 1) {
+        paletteView.setUint16(outPos, srcView.getUint16(srcPos));
+        srcPos += 2;
+        outPos += 2;
+      } else {
+        paletteView.setUint16(outPos, 0);
+        outPos += 2;
+      }
+      paletteMask >>= 1;
+    }
+  }
+
+  return palette;
+};
+
+
+/**
+* Decompresses SPC run-length encoded bitmap data.
+* 
+* @param {ArrayBuffer} buffer - The `ArrayBuffer` containing the compressed data
+* @returns {ArrayBuffer} - A `ArrayBuffer` containing the uncompressed data
+*/
+export const decompressImage = (buffer) => {
+  const srcView = new DataView(buffer);
+  const outBuffer = new ArrayBuffer(IMAGE_HEIGHT * 160);
+  const outView = new DataView(outBuffer);
+  const srcLength = srcView.byteLength - 1;
+
+  let outPos = 0;
+  let srcPos = 0;
+
+  while (srcPos < srcLength) {
+    const header = srcView.getInt8(srcPos++);
+    if (header < 0) {
+      const data = srcView.getUint8(srcPos++);
+      for (let i = -header + 2; i > 0; i--) {
+        outView.setUint8(outPos++, data);
+      }
+    } else {
+      for (let i = header + 1; i > 0; i--) {
+        outView.setUint8(outPos++, srcView.getUint8(srcPos++));
+      }
+    }
+  }
+  return outBuffer;
+};
+
+
+/**
+ * Decodes a compressed Spectrum 512 image and returns a ImageData object
+ * containing the converted data. Colors are converted from 12bit RGB to 32bit 
+ * RGBA format.
+ * 
+ * @param {ArrayBuffer} buffer - An array buffer containing the image
+ * @returns {Promise<DecodedImage>} Decoded image data
+ * @throws {Error} If the image data is invalid
+ */
+export const decode = buffer => {
+  const imageData = new ImageData(IMAGE_WIDTH, IMAGE_HEIGHT);
+  const imageDataView = new DataView(imageData.data.buffer);
+  const bufferView = new DataView(buffer);
+
+  let srcPosition = 0;
+  let destPosition = 0;
+
+  // Check the file header is valid
+  if (bufferView.getUint32(0) !== SPECTRUM_FILE_HEADER) {
+    throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+  }
+
+  const bitmapLength = bufferView.getUint32(4);
+  const paletteLength = bufferView.getUint32(8);
+  const decompressedImageData = decompressImage(buffer.slice(12, 12 + bitmapLength));
+  const decompressedPaletteData = decompressPalette(buffer.slice(12 + bitmapLength, 12 + bitmapLength + paletteLength));
+  const bitplaneView = new DataView(decompressedImageData);
+  const paletteView = new DataView(decompressedPaletteData);
+  const { palette, bitsPerChannel } = createPalette(paletteView);
+
+  // Spectrum images are 199 (not 200) pixels high.
+  for (let line = 0; line < IMAGE_HEIGHT; line++) {
+    for (let c = 0; c < IMAGE_WIDTH / 16; c++) {
+      const indexes = decodeWordsToPaletteIndexes(bitplaneView, srcPosition, 4, imageDataView.byteLength / 64);
+      for (let x = 0; x < indexes.length; x++) {
+        const color = getPaletteColorOffset((c * 16) + x, line, indexes[x]);
+        imageDataView.setUint32(destPosition, palette[color]);
+        destPosition += 4;
+      }
+      srcPosition += 2;
+    }
+  }
+
+  return {
+    palette: new IndexedPalette(bitsPerChannel === 4 ? 4096 : 512, { bitsPerChannel }),
+    imageData
+  };
+};

--- a/imagedata-coder-spectrum512/consts.js
+++ b/imagedata-coder-spectrum512/consts.js
@@ -1,0 +1,13 @@
+export const SPECTRUM_FILE_HEADER = 0x53500000;
+
+export const SPECTRUM_UNCOMPRESSED_FILE_SIZE = 51104;
+
+export const IMAGE_HEIGHT = 199;
+
+export const IMAGE_WIDTH = 320;
+
+export const PALETTES_PER_SCANLINE = 3;
+
+export const COLORS_PER_SCANLINE = PALETTES_PER_SCANLINE * 16;
+
+export const ERROR_MESSAGE_INVALID_FILE_FORMAT = 'Invalid file format';

--- a/imagedata-coder-spectrum512/main.js
+++ b/imagedata-coder-spectrum512/main.js
@@ -1,0 +1,38 @@
+import { decode as decodeUncompressed } from './uncompressed.js';
+import { decode as decodeCompressed } from './compressed.js';
+import { decode as decodeSmooshed } from './smooshed.js';
+import {
+  SPECTRUM_FILE_HEADER,
+  SPECTRUM_UNCOMPRESSED_FILE_SIZE,
+  ERROR_MESSAGE_INVALID_FILE_FORMAT
+} from './consts.js';
+
+/**
+ * @typedef {import('./types.js').DecodedImage} DecodedImage
+ */
+
+/**
+ * Decodes a Spectrum 512 image and returns a ImageData object containing the 
+ * converted data. Colors are converted from 12bit RGB to 32bit RGBA format.
+ * Supports SPU, SPC and SPS variants of the format.
+ * 
+ * @param {ArrayBuffer} buffer - An array buffer containing the image
+ * @returns {Promise<DecodedImage>} Decoded image data
+ * @throws {Error} If the image data is invalid
+ */
+export const decode = async buffer => {
+  const bufferView = new DataView(buffer);
+  if (buffer.byteLength === SPECTRUM_UNCOMPRESSED_FILE_SIZE) {
+    return decodeUncompressed(buffer);
+  } else if (bufferView.getUint32(0) === SPECTRUM_FILE_HEADER) {
+    try {
+      return decodeCompressed(buffer);
+    } catch (e) {
+      try {
+        return decodeSmooshed(buffer);
+      } catch (e) {
+        throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+      }
+    }
+  }
+};

--- a/imagedata-coder-spectrum512/package-lock.json
+++ b/imagedata-coder-spectrum512/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "imagedata-coder-spectrum512",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "imagedata-coder-spectrum512",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "imagedata": "file:../imagedata",
+        "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
+      }
+    },
+    "../imagedata": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "../imagedata-coder-bitplane": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "imagedata": "../imagedata"
+      }
+    },
+    "node_modules/imagedata": {
+      "resolved": "../imagedata",
+      "link": true
+    },
+    "node_modules/imagedata-coder-bitplane": {
+      "resolved": "../imagedata-coder-bitplane",
+      "link": true
+    }
+  },
+  "dependencies": {
+    "imagedata": {
+      "version": "file:../imagedata"
+    },
+    "imagedata-coder-bitplane": {
+      "version": "file:../imagedata-coder-bitplane",
+      "requires": {}
+    }
+  }
+}

--- a/imagedata-coder-spectrum512/package.json
+++ b/imagedata-coder-spectrum512/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "imagedata-coder-spectrum512",
+  "version": "1.0.0",
+  "description": "A coder for working with Atari ST Spectrum 512 files in ImageData objects.",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "imagedata": "file:../imagedata",
+    "imagedata-coder-bitplane": "file:../imagedata-coder-bitplane"
+  },
+  "author": {
+    "name": "Keith Clark",
+    "url": "https://keithclark.co.uk"
+  },
+  "license": "MIT",
+  "type": "module"
+}

--- a/imagedata-coder-spectrum512/smooshed.js
+++ b/imagedata-coder-spectrum512/smooshed.js
@@ -1,0 +1,173 @@
+import BitDataView from './BitReader.js';
+import ImageData from 'imagedata';
+
+import {
+  IndexedPalette,
+  decodeWordsToPaletteIndexes,
+  decodeBytesToPaletteIndexes
+} from 'imagedata-coder-bitplane';
+
+import {
+  createPalette,
+  getPaletteColorOffset
+} from './common.js';
+
+import { 
+  ERROR_MESSAGE_INVALID_FILE_FORMAT,
+  SPECTRUM_FILE_HEADER,
+  IMAGE_HEIGHT,
+  IMAGE_WIDTH,
+  COLORS_PER_SCANLINE,
+  PALETTES_PER_SCANLINE
+} from './consts.js';
+
+/**
+ * @typedef {import('./types.js').DecodedImage} DecodedImage
+ */
+
+
+/**
+ * Decompresses the palette.
+ * 
+ * Each 16 colour palette consists of a header followed by the colour data.
+ * The header is a 14 bit mask where a `1` indicates the colour exists in
+ * the colour data and `0` indicates the colour isn't and should be treated as
+ * black. Colours are stored in 9 bits, `rrrggbb`.
+ * 
+ * @param {ArrayBuffer} buffer - The `ArrayBuffer` containing the compressed data
+ * @returns {ArrayBuffer} An `ArrayBuffer` containing the uncompressed data
+ */
+export const decompressPalette = (buffer) => {
+  const palette = new ArrayBuffer(COLORS_PER_SCANLINE * IMAGE_HEIGHT * 2);
+  const destView = new DataView(palette);
+  const srcView = new BitDataView(buffer);
+
+  let srcPos = 0;
+  let outPos = 0;
+
+  for (let paletteNo = 0; paletteNo < PALETTES_PER_SCANLINE * IMAGE_HEIGHT; paletteNo++) {
+    let header = srcView.getBits(srcPos, 14);
+    srcPos += 14;
+
+    for (let colorNo = 0; colorNo < 16; colorNo++) {
+      if (colorNo === 0 || colorNo === 15) {
+        destView.setUint16(outPos, 0);
+        outPos += 2;
+      } else {
+        if (header & 0x2000) {
+          const bits = srcView.getBits(srcPos, 9);
+          srcPos = srcPos + 9;
+          const r = (bits >> 6) & 7;
+          const g = (bits >> 3) & 7;
+          const b = bits & 7;
+          destView.setUint16(outPos, r << 8 | g << 4 | b);
+          outPos += 2;
+        } else {
+          destView.setUint16(outPos, 0);
+          outPos += 2;
+        }
+        header = header << 1;
+      }
+    }
+  }
+  return palette;
+};
+
+
+/**
+ * Decompresses SPC run-length encoded bitmap data.
+ * 
+ * @param {ArrayBuffer} buffer - The `ArrayBuffer` containing the compressed data
+ * @returns {ArrayBuffer} An `ArrayBuffer` containing the uncompressed data
+ */
+export const decompressImage = (buffer) => {
+  const srcView = new DataView(buffer);
+  const outBuffer = new ArrayBuffer(IMAGE_WIDTH * IMAGE_HEIGHT / 2);
+  const outView = new DataView(outBuffer);
+  const srcLength = srcView.byteLength - 1;
+
+  let outPos = 0;
+  let srcPos = 0;
+
+  while (srcPos < srcLength) {
+    const header = srcView.getUint8(srcPos++);
+    if (header <= 127) {
+      const data = srcView.getUint8(srcPos++);
+      for (let i = header + 3; i > 0; i--) {
+        outView.setUint8(outPos++, data);
+      }
+    } else {
+      for (let i = header - 128 + 1; i > 0; i--) {
+        outView.setUint8(outPos++, srcView.getUint8(srcPos++));
+      }
+    }
+  }
+  return outBuffer;
+};
+
+
+/**
+ * Decodes a "smooshed" Spectrum 512 image and returns a ImageData object
+ * containing the converted data. Colors are converted from 12bit RGB to 32bit 
+ * RGBA format.
+ * 
+ * @param {ArrayBuffer} buffer - An array buffer containing the image
+ * @returns {Promise<DecodedImage>} A promise that resolves with the decoded image
+ * @throws {Error} If the image data is invalid
+ */
+export const decode = (buffer) => {
+  const imageData = new ImageData(IMAGE_WIDTH, IMAGE_HEIGHT);
+  const imageDataView = new DataView(imageData.data.buffer);
+  const bufferView = new DataView(buffer);
+
+  let srcPosition = 0;
+  let destPosition = 0;
+
+  // Check the file header is valid
+  if (bufferView.getUint32(0) !== SPECTRUM_FILE_HEADER) {
+    throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+  }
+
+  const encodingMethod = bufferView.getUint8(buffer.byteLength - 1) & 1;
+  const bitmapLength = bufferView.getUint32(4);
+  const paletteLength = bufferView.getUint32(8);
+  const decompressedImageData = decompressImage(buffer.slice(12, 12 + bitmapLength));
+  const decompressedPaletteData = decompressPalette(buffer.slice(12 + bitmapLength, 12 + bitmapLength + paletteLength));
+  const bitplaneView = new DataView(decompressedImageData);
+  const paletteView = new DataView(decompressedPaletteData);
+  const { palette, bitsPerChannel } = createPalette(paletteView);
+
+  if (encodingMethod === 1) {
+    for (let y = 0; y < IMAGE_HEIGHT; y++) {
+      for (let c = 0; c < IMAGE_WIDTH / 16; c++) {
+        const indexes = decodeWordsToPaletteIndexes(bitplaneView, srcPosition, 4, imageDataView.byteLength / 64);
+        for (let x = 0; x < indexes.length; x++) {
+          const color = getPaletteColorOffset((c * 16) + x, y, indexes[x]);
+          imageDataView.setUint32(destPosition, palette[color]);
+          destPosition += 4;
+        }
+        srcPosition += 2;
+      }
+    }
+  } else {
+    for (let c = 0; c < IMAGE_WIDTH / 8; c++) {
+      srcPosition = c * IMAGE_HEIGHT;
+      destPosition = c * 8 * 4;
+      for (let y = 0; y < IMAGE_HEIGHT; y++) {
+        const indexes = decodeBytesToPaletteIndexes(bitplaneView, srcPosition, 4, IMAGE_HEIGHT * 40);
+        for (let x = 0; x < 8; x++) {
+          const color = getPaletteColorOffset((c * 8) + x, y, indexes[x]);
+          imageDataView.setUint32(destPosition, palette[color]);
+          destPosition += 4;
+        }
+        destPosition += (IMAGE_WIDTH - 8) * 4;
+        srcPosition += 1;
+      }
+    }
+  }
+
+  return {
+    palette: new IndexedPalette(bitsPerChannel === 4 ? 4096 : 512, { bitsPerChannel }),
+    imageData
+  };
+};

--- a/imagedata-coder-spectrum512/types.js
+++ b/imagedata-coder-spectrum512/types.js
@@ -1,0 +1,7 @@
+/**
+ * @typedef {Object} DecodedImage
+ * @property {IndexedPalette} palette - The indexed palette containing the image colors
+ * @property {ImageData} imageData - The ImageData object containing the image
+ */
+
+export default null;

--- a/imagedata-coder-spectrum512/uncompressed.js
+++ b/imagedata-coder-spectrum512/uncompressed.js
@@ -1,0 +1,64 @@
+import ImageData from 'imagedata';
+
+import {
+  IndexedPalette,
+  decodeWordsToPaletteIndexes
+} from 'imagedata-coder-bitplane';
+
+import {
+  createPalette,
+  getPaletteColorOffset
+} from './common.js';
+
+import {
+  ERROR_MESSAGE_INVALID_FILE_FORMAT,
+  IMAGE_HEIGHT,
+  IMAGE_WIDTH,
+  SPECTRUM_UNCOMPRESSED_FILE_SIZE
+} from './consts.js';
+
+/**
+ * @typedef {import('./types.js').DecodedImage} DecodedImage
+ */
+
+
+/**
+ * Decodes a Spectrum 512 image and returns a ImageData object containing the
+ * converted data. Colors are converted from 12bit RGB to 32bit RGBA format
+ *
+ * @param {ArrayBuffer} buffer - An array buffer containing the NEOChrome image
+ * @returns {Promise<DecodedImage>} Decoded image data
+ * @throws {Error} If the image data is invalid
+ */
+export const decode = buffer => {
+  const imageData = new ImageData(IMAGE_WIDTH, IMAGE_HEIGHT);
+  const imageDataView = new DataView(imageData.data.buffer);
+
+  let srcPosition = 160;
+  let destPosition = 0;
+
+  if (buffer.byteLength !== SPECTRUM_UNCOMPRESSED_FILE_SIZE) {
+    throw new Error(ERROR_MESSAGE_INVALID_FILE_FORMAT);
+  }
+
+  const bitplaneView = new DataView(buffer, 0, 32000);
+  const paletteView = new DataView(buffer, 32000);
+  const { palette, bitsPerChannel } = createPalette(paletteView);
+
+  for (let y = 0; y < IMAGE_HEIGHT; y++) {
+    for (let c = 0; c < IMAGE_WIDTH / 16; c++) {
+      const indexes = decodeWordsToPaletteIndexes(bitplaneView, srcPosition, 4, 1);
+      for (let x = 0; x < indexes.length; x++) {
+        const color = getPaletteColorOffset((c * 16) + x, y, indexes[x]);
+        imageDataView.setUint32(destPosition, palette[color]);
+        destPosition += 4;
+      }
+      srcPosition += 8;
+    }
+  }
+
+  return {
+    palette: new IndexedPalette(bitsPerChannel === 4 ? 4096 : 512, { bitsPerChannel }),
+    imageData
+  };
+};

--- a/imagedata/ImageData.js
+++ b/imagedata/ImageData.js
@@ -6,6 +6,10 @@
  */
 export default class ImageData {
 
+  #width;
+  #height;
+  #data;
+
   constructor(...args) {
 
     let arg, data, width, height;
@@ -16,7 +20,7 @@ export default class ImageData {
   
     arg = args.shift();
     if (arg instanceof Uint8ClampedArray) {
-      data = arg;
+      data = arg.slice();
       arg = args.shift();
     } else if (!Number.isInteger(arg)) {
       throw new TypeError('Argument 0 must be an Integer or Uint8ClampedArray');     
@@ -61,9 +65,9 @@ export default class ImageData {
       data = new Uint8ClampedArray(width * height * 4);
     }
 
-    this._height = height;
-    this._width = width;
-    this._data = data;
+    this.#height = height;
+    this.#width = width;
+    this.#data = data;
   }
 
 
@@ -73,7 +77,7 @@ export default class ImageData {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/ImageData/width
    */
   get width() {
-    return this._width;
+    return this.#width;
   }
 
 
@@ -83,7 +87,7 @@ export default class ImageData {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/ImageData/height
    */
   get height() {
-    return this._height;
+    return this.#height;
   }
 
 
@@ -93,7 +97,7 @@ export default class ImageData {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data
    */
   get data() {
-    return this._data;
+    return this.#data;
   }
 
 

--- a/imagedata/index.js
+++ b/imagedata/index.js
@@ -1,4 +1,4 @@
 import ImageData from './ImageData.js';
 
 // eslint-disable-next-line no-undef
-export default (typeof window === 'object') ? window.ImageData : ImageData;
+export default (typeof window === 'object' && 'ImageData' in window) ? window.ImageData : ImageData;


### PR DESCRIPTION
* Adds STe palette support to NEO and Degas coders
* Fixes bug that assumes `ImageData` exists on `window` in browsers.
* Adds two new coders for Spectrum 512 and Crack Art.
* Update bitmap coder to export utility methods