### PR TITLE
Rewrite IFF coder.

### DIFF
--- a/imagedata-coder-bitplane/compression/packbits.js
+++ b/imagedata-coder-bitplane/compression/packbits.js
@@ -16,13 +16,16 @@ export const depack = (buffer, size) => {
 
     let byte = srcBuffer.getInt8(srcPos++);
 
-    if (byte < 0) {
+    if (byte === -128) {
+      // No Op
+    } else if (byte < 0) {
+      // One byte of data, repeated (1 − n) times in the decompressed output
       const byte2 = srcBuffer.getUint8(srcPos++);
-      for (let c = 0;c < 1 - byte;c++) {
+      for (let c = 0; c < 1 - byte; c++) {
         outView.setUint8(destPos++, byte2);
       }
-      // -1 to -127 -> one byte of data repeated (1 - byte) times
     } else {
+      // (1 + n) literal bytes of data
       for (let c = 0; c < 1 + byte; c++) {
         outView.setUint8(destPos++, srcBuffer.getUint8(srcPos++));
       }

--- a/imagedata-coder-iff/IffChunkReader.js
+++ b/imagedata-coder-iff/IffChunkReader.js
@@ -1,0 +1,124 @@
+/**
+ * @typedef IffChunk
+ * @property {string} id - The four-character chunk identifier
+ * @property {number} length - The length of the chunk data
+ * @property {IffChunkReader} reader - A `IffChunkReader` instance for reading chunk contents
+ */
+
+/**
+ * The IffChunkReader interface reads IFF data from an underlying `ArrayBuffer`.
+ * 
+ */
+export class IffChunkReader {
+  
+  /** @type {number} */
+  #pos;
+
+  /** @type {DataView} */
+  #view;
+
+  /** @type {TextDecoder} */
+  #textDecoder;
+
+  /**
+   * Creates a new IffChunkReader from a `ArrayBuffer`. An optional offset and
+   * length can be provided to limit the reader to a sub-set of data in the 
+   * buffer.
+   * 
+   * @param {ArrayBuffer} buffer - The buffer to read from
+   * @param {number?} byteOffset - byte offset into the buffer
+   * @param {number?} byteLength - number of bytes to include
+   */
+  constructor(buffer, byteOffset, byteLength) {
+    this.#pos = 0;
+    this.#view = new DataView(buffer, byteOffset, byteLength);
+    this.#textDecoder = new TextDecoder();
+  }
+
+  /**
+   * Reads the next 8 bit value from the buffer.
+
+   * @returns {number} 8 bit value
+   */
+  readByte() {
+    return this.#view.getUint8(this.#pos++);
+  }
+
+  /**
+   * Reads the next 16 bit (big endian) value from the buffer.
+   * 
+   * @returns {number} 16 bit value
+   */
+  readWord() {
+    const value = this.#view.getUint16(this.#pos);
+    this.#pos += 2;
+    return value;
+  }
+
+  /**
+   * Reads the next 32 bit (big endian) value from the buffer.
+   * 
+   * @returns {number} 32 bit value
+   */
+  readLong() {
+    const value = this.#view.getUint32(this.#pos);
+    this.#pos += 4;
+    return value;
+  }
+
+  /**
+   * Reads a specified number of bytes from the buffer
+   * 
+   * @param {number} length The number of bytes to read
+   * @returns {ArrayBuffer} an ArrayBuffer of bytes
+   */
+  readBytes(length) {
+    const bytes = this.#view.buffer.slice(this.#view.byteOffset + this.#pos, this.#pos + this.#view.byteOffset + length);
+    this.#pos += bytes.byteLength;
+    return bytes;
+  }
+
+  /**
+   * Reads an ASCII encoded string from the buffer
+   * 
+   * @param {number} length The number of bytes to read
+   * @returns {string} The decoded string
+   */
+  readString(length) {
+    return this.#textDecoder.decode(this.readBytes(length));
+  }
+
+  /**
+   * Reads the next IFF chunk from the buffer.
+   * 
+   * @returns {IffChunk}
+   */
+  readChunk() {
+    const id = this.readString(4);
+    const length = this.readLong();
+    const dataStart = this.#view.byteOffset + this.#pos;
+    const reader = new IffChunkReader(this.#view.buffer, dataStart, length);
+    this.#pos += length;
+
+    // IFF chunks are word aligned so, if the current offset is even, move over
+    // the padding byte.
+    if (this.#pos % 2 === 1 && !this.eof()) {
+      this.#pos++;
+    }
+
+    return {
+      id,
+      length,
+      reader
+    };
+  }
+
+  /**
+   * Indicates if the reader has reached the end of the buffer or not.
+   * 
+   * @returns {boolean} `true` if all data has been read, or `false` if there is more to read.
+   */
+  eof() {
+    return this.#pos === this.#view.byteLength;
+  }
+}

--- a/imagedata-coder-iff/README.md
+++ b/imagedata-coder-iff/README.md
@@ -1,0 +1,9 @@
+# IFF to `ImageData` coder
+
+This module decodes planar IFF images into `ImageData` objects so they can be rendered to canvas elements.
+
+Supports:
+
+* ILBM and ACBM formats.
+* Uncompressed, Packbits and Atari ST compression methods.
+* Amiga EHB (Extra-Halfbright) mode.

--- a/imagedata-coder-iff/consts.js
+++ b/imagedata-coder-iff/consts.js
@@ -1,32 +1,11 @@
-/** IFF chunk identifier */
-export const CHUNK_ID_FORM = 0x464f524d;
-
-/** Interlaced bitmap chunk identifier */
-export const CHUNK_ID_ILBM = 0x494c424d;
-
-/** Contiguous bitmap chunk identifier */
-export const CHUNK_ID_ACBM = 0x4143424d;
-
-/** Bitmap header chunk identifier */
-export const CHUNK_ID_BMHD = 0x424d4844;
-
-/** Colour palette chunk identifier */
-export const CHUNK_ID_CMAP = 0x434d4150;
-
-/** Amiga display mode chunk identifier */
-export const CHUNK_ID_CAMG = 0x43414d47;
-
-/** ILBM image body chunk identifier */
-export const CHUNK_ID_BODY = 0x424f4459;
-
-/** ACBM bitmap data chunk identifier */
-export const CHUNK_ID_ABIT = 0x41424954;
-
 /** Data is uncompressed */
 export const COMPRESSION_NONE = 0;
 
-/** Data uses Packbits compression */
+/** Data is compressed using the Packbits method */
 export const COMPRESSION_PACKBITS = 1;
 
-/** Amiga Extra Half-Brite mode */
+/** Data is compressed using the Atari ST method (VDAT chunks in BODY) */
+export const COMPRESSION_ATARI = 2;
+
+/** Image uses the Amiga Extra Half-Brite mode */
 export const AMIGA_MODE_EHB = 0x80;


### PR DESCRIPTION
This is a rewrite of the IFF coder. Decoding is more forgiving of badly implemented IFF writes that don't follow the spec and write blocks out of order. 

This change also adds support for the Atari ST compression method which uses the `BODY` chunk as a container. The `BODY` contains a `VDAT` chunk for each bitplane of the image. The data in these `VDAT` chunks are compressed using a vertical run-length encoding