### PR TITLE
Spectrum 512 export palettes

### DIFF
--- a/imagedata-coder-bitplane/lib/LineInterleavedBitplaneReader.js
+++ b/imagedata-coder-bitplane/lib/LineInterleavedBitplaneReader.js
@@ -14,7 +14,7 @@ export default class LineInterleavedBitplaneReader extends BitplaneReader {
    * @param {number} width - The width of the image in pixels
    */
   constructor(buffer, planes, width) {
-    const bytesPerLine = (width >> 3);
+    const bytesPerLine = width >> 3;
     super(buffer, bytesPerLine, 0, 1, bytesPerLine * planes, planes, bytesPerLine);
   }
 }

--- a/imagedata-coder-degas/decode.js
+++ b/imagedata-coder-degas/decode.js
@@ -1,6 +1,6 @@
 import { ENCODING_FORMAT_LINE, ENCODING_FORMAT_WORD, decode as decodeBitplanes } from 'imagedata-coder-bitplane';
 import { depack } from 'imagedata-coder-bitplane/compression/packbits.js';
-import { createAtariStIndexedPalette } from 'imagedata-coder-bitplane';
+import { createAtariStIndexedPalette, IndexedPalette } from 'imagedata-coder-bitplane';
 import ImageData from 'imagedata';
 
 /**
@@ -43,11 +43,17 @@ export const decode = async (buffer) => {
     throw new Error('Invalid file format');
   }
   
+  let palette;
+
   const width = res === 0 ? 320 : 640;
   const height = res === 2 ? 400 : 200;
   const planes = 4 >> res;
   const colors = 1 << planes;
-  const palette = createAtariStIndexedPalette(new Uint8Array(buffer, 2, colors * 2), colors);
+  if (planes === 1) {
+    palette = IndexedPalette.fromValueArray([0xffffffff, 0x000000ff]);
+  } else {
+    palette = createAtariStIndexedPalette(new Uint8Array(buffer, 2, colors * 2), colors);
+  }
   const imageData = new ImageData(width, height);
   if (compressed) {
     const bitplaneData = new Uint8Array(depack(buffer.slice(34), 32000));

--- a/imagedata-coder-spectrum512/common.js
+++ b/imagedata-coder-spectrum512/common.js
@@ -1,39 +1,5 @@
-/**
- * Generates a palette lookup table
- * 
- * @param {DataView} paletteView - A DataView of the buffer containing the palette
- * @returns {Array<Number>} Array of colours
- */
-export const createPalette = (paletteView) => {
-  const palette = new Array(48 * 199);
-  let q = 0;
-  let isSte = false;
-  let scale = 255 / 15;
-  for (let line = 0; line < 199; line++) {
-    for (let c = 0; c < 48; c++) {
-      const color = paletteView.getUint16(line * 2 * 48 + c * 2);
-      let r = color >> 8 & 0xf;
-      let g = color >> 4 & 0xf;
-      let b = color >> 0 & 0xf;
-
-      if (!isSte && (r > 7 | g > 7 | b > 7)) {
-        isSte = true;
-      }
-
-      r = ((r & 8) >>> 3) | (r << 1) & 0xf;
-      g = ((g & 8) >>> 3) | (g << 1) & 0xf;
-      b = ((b & 8) >>> 3) | (b << 1) & 0xf;
-
-      palette[q++] = ((scale * r) << 24) + ((scale * g) << 16) + ((scale * b) << 8) + 255 >>> 0;
-    }
-  }
-
-  return {
-    bitsPerChannel: isSte ? 4 : 3,
-    palette
-  };
-};
-
+import { createAtariStIndexedPalette } from 'imagedata-coder-bitplane';
+import { COLORS_PER_SCANLINE, IMAGE_HEIGHT } from "./consts.js";
 
 /**
  * 
@@ -57,3 +23,22 @@ export const getPaletteColorOffset = (x, y, c) => {
   }
   return c + (y * 48);
 };
+
+
+/**
+ * Creates an array of IndexPalette objects from a buffer of RGB values.
+ * 
+ * @param {ArrayBuffer} buffer Buffer containing the palette entries
+ * @param {number} [offset=0] Optional offset to the first byte of palette data
+ * @returns {Array<IndexedPalette>} An array containing the color palettes of each line of the image
+ */
+export const createPaletteArray = (buffer, offset = 0) => {
+  const palettes = [];
+  // Extract the 199 palettes (48 colours)
+  for (let c = 0; c < IMAGE_HEIGHT; c++) {
+    const paletteBuffer = new Uint8Array(buffer, offset, COLORS_PER_SCANLINE * 2);
+    palettes.push(createAtariStIndexedPalette(paletteBuffer, COLORS_PER_SCANLINE));
+    offset += COLORS_PER_SCANLINE * 2;
+  }
+  return palettes;
+}

--- a/imagedata-coder-spectrum512/consts.js
+++ b/imagedata-coder-spectrum512/consts.js
@@ -11,3 +11,15 @@ export const PALETTES_PER_SCANLINE = 3;
 export const COLORS_PER_SCANLINE = PALETTES_PER_SCANLINE * 16;
 
 export const ERROR_MESSAGE_INVALID_FILE_FORMAT = 'Invalid file format';
+
+/** Image is not compressed */
+export const COMPRESSION_METHOD_NONE = 0;
+
+/** Standard compression format */
+export const COMPRESSION_METHOD_COMPRESSED = 1;
+
+/** "Smooshed" compression format with image stored as contiguous bitplanes (same as SPC) */
+export const COMPRESSION_METHOD_SMOOSHED = 2;
+
+/** "Smooshed" compression format with data stored as byte-wide vertical strips */
+export const COMPRESSION_METHOD_SMOOSHED_VERTICAL = 3;

--- a/imagedata-coder-spectrum512/main.js
+++ b/imagedata-coder-spectrum512/main.js
@@ -8,21 +8,8 @@ import {
 } from './consts.js';
 
 /**
- * @typedef {import('./types.js').DecodedImage} DecodedImage
+ * @typedef {import('./types.js').Spectrum512Image} Spectrum512Image
  */
-
-/**
- * @typedef Spectrum512ImageMetadata
- * @property {IndexedPalette} palette The color palette for the image
- * @property {boolean} compressed Is the image data compressed
- */
-
-/**
- * @typedef Spectrum512Image
- * @property {ImageData} imageData - The ImageData object containing the image
- * @property {Spectrum512ImageMetadata} meta - The indexed palette containing the image colors
- */
-
 
 /**
  * Decodes a Spectrum 512 image and returns a ImageData object containing the 
@@ -33,7 +20,7 @@ import {
  * @returns {Promise<Spectrum512Image>} Decoded image data
  * @throws {Error} If the image data is invalid
  */
-export const decode = async (buffer) => {
+export const decode = (buffer) => {
   const bufferView = new DataView(buffer);
   if (buffer.byteLength === SPECTRUM_UNCOMPRESSED_FILE_SIZE) {
     return decodeUncompressed(buffer);

--- a/imagedata-coder-spectrum512/types.js
+++ b/imagedata-coder-spectrum512/types.js
@@ -1,0 +1,13 @@
+/**
+ * @typedef Spectrum512ImageMetadata
+ * @property {Array<IndexedPalette>} palette The color palettes for the image
+ * @property {number} compression The compression method used for the image
+ */
+
+/**
+ * @typedef Spectrum512Image
+ * @property {ImageData} imageData - The ImageData object containing the image
+ * @property {Spectrum512ImageMetadata} meta - The image metadata
+ */
+
+export default null;


### PR DESCRIPTION
This PR modified the Spectrum 512 coder to returns the palette for a decoded image in the image metadata so they can be used to rebuild the image later.

Also fixes an issue with the Degas coder not using black and white for monochrome images